### PR TITLE
Small css adjustments

### DIFF
--- a/client/packages/base/orderhistorylistitem/ui/index.scss
+++ b/client/packages/base/orderhistorylistitem/ui/index.scss
@@ -1,5 +1,6 @@
 .history-list-item {
 	padding: 2rem 1.75rem;
+	min-width: 350px;
 
 	&__top-div {
 		gap: 5.6rem;

--- a/client/packages/base/orderhistorylistitem/ui/index.tsx
+++ b/client/packages/base/orderhistorylistitem/ui/index.tsx
@@ -88,4 +88,6 @@ export const OrderHistoryListItem = ({ order }: Props) => {
  * Author: Klara Sköld
  * Created a list item for each object in the users order history
  *
+ * Update: Klara
+ * Added max-width on cards.
  */

--- a/client/packages/base/page/ui/index.scss
+++ b/client/packages/base/page/ui/index.scss
@@ -5,10 +5,6 @@
 	&__wrapper {
 		padding: 3rem 10rem 8rem 10rem;
 	}
-
-	&__title {
-		margin-bottom: 2rem;
-	}
 }
 
 @media screen and (max-width: 992px) {

--- a/client/packages/base/page/ui/index.tsx
+++ b/client/packages/base/page/ui/index.tsx
@@ -17,7 +17,7 @@ export const Page = ({
 	srOnly,
 	extraClasses,
 }: Props) => {
-	const classNames = clsx('heading-1', 'page__title', {
+	const classNames = clsx('heading-1', {
 		'sr-only': srOnly,
 	});
 	return (
@@ -37,4 +37,7 @@ export const Page = ({
  *
  * Update: Lam
  * Added gap for page
+ *
+ * Update: Klara
+ * Removed margin-bottom on h1
  */

--- a/client/packages/base/productcard/ui/index.scss
+++ b/client/packages/base/productcard/ui/index.scss
@@ -2,17 +2,17 @@
 	position: relative;
 	gap: 1rem;
 	flex: 1;
-	max-width: 250px;
+	max-width: 150px;
 	&__img-box {
 		aspect-ratio: 1;
-		max-width: 150px;
+		// max-width: 150px;
 		border-radius: 4px;
 		justify-content: center;
 		align-items: center;
 		position: relative;
 
 		.product-card__img {
-			width: 60%;
+			// width: 60%;
 			cursor: pointer;
 		}
 

--- a/client/packages/base/productcard/ui/index.tsx
+++ b/client/packages/base/productcard/ui/index.tsx
@@ -12,6 +12,9 @@ import { ModalProductCard } from '../../modalproductcard/ui';
  *
  * Update: Klara
  * When the user clicks on a product card a modal opens.
+ *
+ * Update: Klara
+ * Updated maxwidth on card, same width on card and img.
  */
 
 type Props = {

--- a/client/packages/base/productslist/ui/index.scss
+++ b/client/packages/base/productslist/ui/index.scss
@@ -1,7 +1,7 @@
 .product-list {
 	width: 100%;
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
 	column-gap: 2rem;
 	row-gap: 3.5rem;
 

--- a/client/packages/base/productslist/ui/index.tsx
+++ b/client/packages/base/productslist/ui/index.tsx
@@ -14,6 +14,8 @@ import { CartProductCard } from '@mojjen/cartproductcard';
  * Update: Lam
  * Removed OrderItem and replaced with Meal[]
  *
+ * Update: Klara
+ * Switched from autofit to autofill on grid to avoid extra spacing between columns
  * */
 
 type Props =

--- a/client/packages/pages/menupage/ui/index.scss
+++ b/client/packages/pages/menupage/ui/index.scss
@@ -1,7 +1,7 @@
 .menu {
 	gap: 2rem;
 	&__top-content {
-		margin-bottom: 6rem;
+		margin-bottom: 5rem;
 	}
 
 	&__button {

--- a/client/packages/pages/menupage/ui/index.tsx
+++ b/client/packages/pages/menupage/ui/index.tsx
@@ -156,6 +156,9 @@ export const MenuPage = () => {
  *
  * Update: Klara
  * Added extra spacing between recent orders and menu
+ *
+ * Update: Klara
+ * Edited the space between recept orders and menu.
  */
 
 // ! Original

--- a/client/packages/pages/profilepage/ui/index.scss
+++ b/client/packages/pages/profilepage/ui/index.scss
@@ -2,6 +2,10 @@
 	gap: 6rem;
 
 	&__orders-list {
-		flex-wrap: wrap;
+		width: 100%;
+
+		grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+		column-gap: 2rem;
+		row-gap: 3.5rem;
 	}
 }

--- a/client/packages/pages/profilepage/ui/index.tsx
+++ b/client/packages/pages/profilepage/ui/index.tsx
@@ -37,9 +37,7 @@ export const ProfilePage = () => {
 			<ProfileForm />
 			<div className="flex flex__column flex__gap-2">
 				<h3 className="heading-3">Orderhistorik</h3>
-				<ul className="flex flex__gap-2 profile__orders-list">
-					{generateListItems()}
-				</ul>
+				<ul className="grid profile__orders-list">{generateListItems()}</ul>
 			</div>
 		</Page>
 	);
@@ -48,4 +46,7 @@ export const ProfilePage = () => {
 /**
  * Author: Klara
  * Profile page, shows profile info and order history.
+ *
+ * Update: Klara
+ * Switched from flex to grid on ul. Now all order history card has the same width.
  */


### PR DESCRIPTION
- Grid fix on recent orders
- Product card width (no text falling out)
- From flex to grid on order history cards to avoid mixed widths on cards
- Removed margin-bottom on page h1